### PR TITLE
Fix: Correct import logic for Proprietario and Imovel

### DIFF
--- a/frontend/desktop/js/modules/importacao.js
+++ b/frontend/desktop/js/modules/importacao.js
@@ -85,9 +85,9 @@ class ImportacaoModule {
                 this.uiManager?.showSuccess(response.data?.mensagem || successMsg);
                 // Atualiza listas se módulos estiverem disponíveis
                 // Eliminado: recarga de proprietarios en la pantalla de importar
-                if (window.imoveisModule && tipo === 'imoveis' && typeof window.imoveisModule.loadImoveis === 'function') {
+                /* if (window.imoveisModule && tipo === 'imoveis' && typeof window.imoveisModule.loadImoveis === 'function') {
                     window.imoveisModule.loadImoveis();
-                }
+                } */
                 if (window.participacoesModule && tipo === 'participacoes' && typeof window.participacoesModule.loadParticipacoes === 'function') {
                     window.participacoesModule.loadParticipacoes();
                 }


### PR DESCRIPTION
This commit addresses two issues:
1. Improves the duplicate check for new 'proprietarios' during import to prevent duplicate entries.
2. Removes the automatic refresh of the 'imoveis' list after import to prevent unintended side-effects on other screens.