### PR TITLE
Fix: Disable vertical scrolling on desktop screens

### DIFF
--- a/frontend/css/responsive.css
+++ b/frontend/css/responsive.css
@@ -384,6 +384,10 @@ body {
     position: relative;
 }
 
+.device-desktop .main-body {
+    overflow-y: hidden !important;
+}
+
 /* PWA específico */
 .pwa-mode .main-header {
     padding-top: env(safe-area-inset-top);

--- a/frontend/unified/css/responsive.css
+++ b/frontend/unified/css/responsive.css
@@ -384,6 +384,10 @@ body {
     position: relative;
 }
 
+.device-desktop .main-body {
+    overflow-y: hidden !important;
+}
+
 /* PWA específico */
 .pwa-mode .main-header {
     padding-top: env(safe-area-inset-top);


### PR DESCRIPTION
This commit disables vertical scrolling on all desktop screens by adding a CSS rule to set 'overflow-y: hidden' on the '.main-body' element when the '.device-desktop' class is present.

This change addresses the user's request to have fixed screens without scrolling on the desktop version of the application. The same change has been applied to both 'frontend/css/responsive.css' and 'frontend/unified/css/responsive.css' to ensure consistency across the duplicated frontend codebases.